### PR TITLE
Bugs in ofTypesetter.cpp and ofFont.cpp

### DIFF
--- a/src/ofFont.cpp
+++ b/src/ofFont.cpp
@@ -864,7 +864,7 @@ void ofFont::drawCharTex(ofUniCharGlyphIdx glyphIdx , ofPoint position) {
 
 //-----------------------------------------------------------
 void ofFont::drawCharTex(ofUniChar unicode, ofPoint position) {
-    drawChar(unicode,unicode,false);
+    drawChar(unicode,position,false);
 }
 
 

--- a/src/ofTypesetter.cpp
+++ b/src/ofTypesetter.cpp
@@ -39,7 +39,7 @@ ofTypesetter::~ofTypesetter() {}
 //------------------------------------------------------------------
 void ofTypesetter::setFont(ofFont* _font) {
     if(_font != NULL) {
-        font = font;
+        font = _font;
     }
 }
 


### PR DESCRIPTION
I was trying to use ofxFont for a project and Xcode was yelling at me: 
1. In ofTypesetter.cpp, the setFont method was setting `font` to itself, when it should be setting it to `_font`.
2. In ofFont.cpp, the overloaded drawCharTex method was trying drawing the text at position `unicode`, where I assumed you meant position.

DISCLAIMER: This is my first pull request and my first time using your library. Let me know if these fixes aren't valid for any reason. Thanks! 
